### PR TITLE
[Bug]: Cannot unpickle CookieJar #35

### DIFF
--- a/tls_requests/__version__.py
+++ b/tls_requests/__version__.py
@@ -3,5 +3,5 @@ __description__ = "A powerful and lightweight Python library for making secure a
 __url__ = "https://github.com/thewebscraping/tls-requests"
 __author__ = "Tu Pham"
 __author_email__ = "thetwofarm@gmail.com"
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 __license__ = "MIT"

--- a/tls_requests/models/cookies.py
+++ b/tls_requests/models/cookies.py
@@ -350,6 +350,7 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
         """Unlike a normal CookieJar, this class is pickleable."""
         self.__dict__.update(state)
         if "_cookies_lock" not in self.__dict__:
+            import threading
             self._cookies_lock = threading.RLock()
 
     def copy(self):

--- a/tls_requests/models/response.py
+++ b/tls_requests/models/response.py
@@ -53,7 +53,6 @@ class Response:
         self._is_closed = False
         self._next: Optional[Request] = None
         self.headers = Headers(headers)
-        self.stream = None
         self.status_code = status_code
         self.history = history if isinstance(history, list) else []
         self.default_encoding = default_encoding
@@ -135,6 +134,7 @@ class Response:
             msg = Message()
             msg["content-type"] = self.headers["Content-Type"]
             return msg.get_content_charset(failobj=None)
+        return None
 
     @property
     def encoding(self) -> str:
@@ -227,6 +227,10 @@ class Response:
             self._is_closed = True
             self._is_stream_consumed = True
             self.stream.close()
+
+        # Fix pickle dump
+        # Ref: https://github.com/thewebscraping/tls-requests/issues/35
+        self.stream = None
 
     async def aclose(self) -> None:
         return self.close()


### PR DESCRIPTION
[Bug]: Cannot unpickle CookieJar #35

- Allows successful unpickling of Response objects with cookie jars without errors.
- Enables persistence and restoration of TLS Requests responses using pickle.