### PR TITLE
Add response and request attributes to HTTPError

### DIFF
--- a/tls_requests/exceptions.py
+++ b/tls_requests/exceptions.py
@@ -21,8 +21,13 @@ __all__ = [
 class HTTPError(Exception):
     """HTTP Error"""
 
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: str, **kwargs) -> None:
         self.message = message
+        response = kwargs.pop("response", None)
+        self.response = response
+        self.request = kwargs.pop("request", None)
+        if response is not None and not self.request and hasattr(response, "request"):
+            self.request = self.response.request
 
 
 class ProtocolError(HTTPError):

--- a/tls_requests/models/response.py
+++ b/tls_requests/models/response.py
@@ -197,7 +197,8 @@ class Response:
                         else StatusCodes.get_reason(self.status_code)
                     ),
                     self.url,
-                )
+                ),
+                response=self,
             )
 
         return self


### PR DESCRIPTION
These attributes are added to align with the implementation in the [requests](https://github.com/psf/requests) library.

References:
[requests.models.Response](https://github.com/psf/requests/blob/main/src/requests/models.py)
[requests.exceptions.RequestException](https://github.com/psf/requests/blob/main/src/requests/exceptions.py)