### PR TITLE
feat: upgrade tls-client to v1.13.1 and refactor library management

### DIFF
--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -2,6 +2,7 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
 import tls_requests
+from tls_requests.models.tls import TLSConfig
 
 
 def hook_request_headers(_request: Request, response: Response) -> Response:
@@ -38,3 +39,47 @@ def test_response_case_insensitive_headers(httpserver: HTTPServer):
     response = tls_requests.get(httpserver.url_for("/headers"))
     assert response.status_code, 200
     assert response.headers["foo"] == "bar"
+
+
+def test_chrome_dynamic_headers():
+    # Test chrome_112
+    config = TLSConfig.from_kwargs(tls_identifier="chrome_112")
+    headers = config.headers
+    assert "Chrome/112" in headers.get("user-agent", "")
+    assert 'v="112"' in headers.get("sec-ch-ua", "")
+
+    # Test chrome_133 (default)
+    config_default = TLSConfig.from_kwargs(tls_identifier="chrome_133")
+    headers_default = config_default.headers
+    assert "Chrome/133" in headers_default.get("user-agent", "")
+    assert 'v="133"' in headers_default.get("sec-ch-ua", "")
+
+
+def test_firefox_dynamic_headers():
+    # Test firefox_120
+    config = TLSConfig.from_kwargs(tls_identifier="firefox_120")
+    headers = config.headers
+    assert "Firefox/120" in headers.get("user-agent", "")
+    assert "rv:120" in headers.get("user-agent", "")
+
+
+def test_safari_dynamic_headers():
+    # Test safari_17
+    config = TLSConfig.from_kwargs(tls_identifier="safari_17")
+    headers = config.headers
+    assert "Version/17" in headers.get("user-agent", "")
+
+
+def test_custom_headers_override():
+    # Custom headers should not be overridden by dynamic injection
+    custom_headers = {"User-Agent": "MyCustomUA", "X-Test": "Value"}
+    config = TLSConfig.from_kwargs(tls_identifier="chrome_112", headers=custom_headers)
+    assert config.headers["User-Agent"] == "MyCustomUA"
+    assert config.headers["X-Test"] == "Value"
+    assert "sec-ch-ua" not in config.headers  # Should not inject if headers provided
+
+
+def test_no_injection_for_non_browser():
+    # Injection should only happen for chrome/firefox/safari
+    config = TLSConfig.from_kwargs(tls_identifier="okhttp4_android_12")
+    assert not config.headers  # Should be empty or only basic defaults if any

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,0 +1,45 @@
+import tls_requests
+from tls_requests.models.tls import TLSConfig
+
+
+def test_protocol_racing_parameters():
+    # Test passing protocol_racing to Client and request
+    with tls_requests.Client(protocol_racing=True) as client:
+        assert client.protocol_racing is True
+        # We can't easily verify the actual network behavior without a specialized mock
+        # but we can check if it's passed correctly to the config
+
+    resp = tls_requests.get("https://httpbin.org/get", protocol_racing=True)
+    assert resp.status_code == 200
+
+
+def test_allow_http_parameters():
+    # Test with_allow_http
+    with tls_requests.Client(allow_http=True) as client:
+        assert client.allow_http is True
+
+    # Test request parameter
+    resp = tls_requests.get("https://httpbin.org/get", allow_http=True)
+    assert resp.status_code == 200
+
+
+def test_stream_id_parameters():
+    # Test stream_id
+    with tls_requests.Client(stream_id=1) as client:
+        assert client.stream_id == 1
+
+
+def test_extra_kwargs_persistence():
+    # Test that extra kwargs are preserved in TLSConfig
+    config = TLSConfig.from_kwargs(local_address="127.0.0.1", random_extra="value")
+    payload = config.to_payload()
+    assert payload.get("localAddress") == "127.0.0.1"
+    assert payload.get("randomExtra") == "value"
+
+
+def test_client_initialization_with_extra_kwargs():
+    # Test passing extra kwargs to Client
+    with tls_requests.Client(local_address="127.0.0.1") as client:
+        # Check if the internal config has it
+        payload = client._config.to_payload()
+        assert payload.get("localAddress") == "127.0.0.1"

--- a/tls_requests/api.py
+++ b/tls_requests/api.py
@@ -5,7 +5,8 @@ import typing
 from .client import Client
 from .models import Response
 from .settings import (DEFAULT_FOLLOW_REDIRECTS, DEFAULT_TIMEOUT,
-                       DEFAULT_TLS_HTTP2, DEFAULT_TLS_IDENTIFIER)
+                       DEFAULT_TLS_ALLOW_HTTP, DEFAULT_TLS_HTTP2,
+                       DEFAULT_TLS_IDENTIFIER, DEFAULT_TLS_PROTOCOL_RACING)
 from .types import (AuthTypes, CookieTypes, HeaderTypes, MethodTypes,
                     ProtocolTypes, ProxyTypes, RequestData, RequestFiles,
                     TimeoutTypes, TLSIdentifierTypes, URLParamTypes, URLTypes)
@@ -39,6 +40,9 @@ def request(
     follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
     verify: bool = True,
     tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    protocol_racing: bool = DEFAULT_TLS_PROTOCOL_RACING,
+    allow_http: bool = DEFAULT_TLS_ALLOW_HTTP,
+    stream_id: typing.Optional[int] = None,
     **config,
 ) -> Response:
     """
@@ -81,6 +85,9 @@ def request(
         timeout=timeout,
         verify=verify,
         client_identifier=tls_identifier,
+        protocol_racing=protocol_racing,
+        allow_http=allow_http,
+        stream_id=stream_id,
         **config,
     ) as client:
         return client.request(
@@ -94,6 +101,9 @@ def request(
             auth=auth,
             follow_redirects=follow_redirects,
             timeout=timeout,
+            protocol_racing=protocol_racing,
+            allow_http=allow_http,
+            stream_id=stream_id,
         )
 
 
@@ -110,6 +120,9 @@ def get(
     follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
     verify: bool = True,
     tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    protocol_racing: bool = DEFAULT_TLS_PROTOCOL_RACING,
+    allow_http: bool = DEFAULT_TLS_ALLOW_HTTP,
+    stream_id: typing.Optional[int] = None,
     **config,
 ) -> Response:
     """
@@ -133,6 +146,9 @@ def get(
         timeout=timeout,
         verify=verify,
         tls_identifier=tls_identifier,
+        protocol_racing=protocol_racing,
+        allow_http=allow_http,
+        stream_id=stream_id,
         **config,
     )
 
@@ -150,6 +166,9 @@ def options(
     follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
     verify: bool = True,
     tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    protocol_racing: bool = DEFAULT_TLS_PROTOCOL_RACING,
+    allow_http: bool = DEFAULT_TLS_ALLOW_HTTP,
+    stream_id: typing.Optional[int] = None,
     **config,
 ) -> Response:
     """
@@ -173,6 +192,9 @@ def options(
         timeout=timeout,
         verify=verify,
         tls_identifier=tls_identifier,
+        protocol_racing=protocol_racing,
+        allow_http=allow_http,
+        stream_id=stream_id,
         **config,
     )
 
@@ -190,6 +212,9 @@ def head(
     follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
     verify: bool = True,
     tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    protocol_racing: bool = DEFAULT_TLS_PROTOCOL_RACING,
+    allow_http: bool = DEFAULT_TLS_ALLOW_HTTP,
+    stream_id: typing.Optional[int] = None,
     **config,
 ) -> Response:
     """
@@ -213,6 +238,9 @@ def head(
         follow_redirects=follow_redirects,
         verify=verify,
         tls_identifier=tls_identifier,
+        protocol_racing=protocol_racing,
+        allow_http=allow_http,
+        stream_id=stream_id,
         **config,
     )
 
@@ -233,6 +261,9 @@ def post(
     follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
     verify: bool = True,
     tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    protocol_racing: bool = DEFAULT_TLS_PROTOCOL_RACING,
+    allow_http: bool = DEFAULT_TLS_ALLOW_HTTP,
+    stream_id: typing.Optional[int] = None,
     **config,
 ) -> Response:
     """
@@ -256,6 +287,9 @@ def post(
         follow_redirects=follow_redirects,
         verify=verify,
         tls_identifier=tls_identifier,
+        protocol_racing=protocol_racing,
+        allow_http=allow_http,
+        stream_id=stream_id,
         **config,
     )
 
@@ -276,6 +310,9 @@ def put(
     follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
     verify: bool = True,
     tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    protocol_racing: bool = DEFAULT_TLS_PROTOCOL_RACING,
+    allow_http: bool = DEFAULT_TLS_ALLOW_HTTP,
+    stream_id: typing.Optional[int] = None,
     **config,
 ) -> Response:
     """
@@ -299,6 +336,9 @@ def put(
         follow_redirects=follow_redirects,
         verify=verify,
         tls_identifier=tls_identifier,
+        protocol_racing=protocol_racing,
+        allow_http=allow_http,
+        stream_id=stream_id,
         **config,
     )
 
@@ -319,6 +359,9 @@ def patch(
     follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
     verify: bool = True,
     tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    protocol_racing: bool = DEFAULT_TLS_PROTOCOL_RACING,
+    allow_http: bool = DEFAULT_TLS_ALLOW_HTTP,
+    stream_id: typing.Optional[int] = None,
     **config,
 ) -> Response:
     """
@@ -342,6 +385,9 @@ def patch(
         follow_redirects=follow_redirects,
         verify=verify,
         tls_identifier=tls_identifier,
+        protocol_racing=protocol_racing,
+        allow_http=allow_http,
+        stream_id=stream_id,
         **config,
     )
 
@@ -359,6 +405,9 @@ def delete(
     follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
     verify: bool = True,
     tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    protocol_racing: bool = DEFAULT_TLS_PROTOCOL_RACING,
+    allow_http: bool = DEFAULT_TLS_ALLOW_HTTP,
+    stream_id: typing.Optional[int] = None,
     **config,
 ) -> Response:
     """
@@ -382,5 +431,8 @@ def delete(
         follow_redirects=follow_redirects,
         verify=verify,
         tls_identifier=tls_identifier,
+        protocol_racing=protocol_racing,
+        allow_http=allow_http,
+        stream_id=stream_id,
         **config,
     )

--- a/tls_requests/models/libraries.py
+++ b/tls_requests/models/libraries.py
@@ -18,8 +18,9 @@ logger = get_logger("TLSLibrary")
 
 __all__ = ["TLSLibrary"]
 
-LATEST_VERSION_TAG_NAME = "v1.11.2"
+LATEST_VERSION_TAG_NAME = "v1.13.1"
 BIN_DIR = os.path.join(Path(__file__).resolve(strict=True).parent.parent / "bin")
+RELEASE_CONFIG_PATH = os.path.join(BIN_DIR, "release.json")
 GITHUB_API_URL = "https://api.github.com/repos/bogdanfinn/tls-client/releases"
 PLATFORM = sys.platform
 IS_UBUNTU = False
@@ -135,96 +136,6 @@ class TLSLibrary:
 
     _PATH: str = None
     _LIBRARY: Optional[ctypes.CDLL] = None
-    _STATIC_API_DATA = {
-        "name": "v1.11.2",
-        "tag_name": "v1.11.2",
-        "assets": [
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-darwin-amd64-1.11.2.dylib",
-                "name": "tls-client-darwin-amd64-1.11.2.dylib",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-darwin-arm64-1.11.2.dylib",
-                "name": "tls-client-darwin-arm64-1.11.2.dylib",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-linux-alpine-amd64-1.11.2.so",
-                "name": "tls-client-linux-alpine-amd64-1.11.2.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-linux-arm64-1.11.2.so",
-                "name": "tls-client-linux-arm64-1.11.2.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-linux-armv7-1.11.2.so",
-                "name": "tls-client-linux-armv7-1.11.2.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-linux-ubuntu-amd64-1.11.2.so",
-                "name": "tls-client-linux-ubuntu-amd64-1.11.2.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-windows-32-1.11.2.dll",
-                "name": "tls-client-windows-32-1.11.2.dll",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-windows-64-1.11.2.dll",
-                "name": "tls-client-windows-64-1.11.2.dll",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-darwin-amd64.dylib",
-                "name": "tls-client-xgo-1.11.2-darwin-amd64.dylib",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-darwin-arm64.dylib",
-                "name": "tls-client-xgo-1.11.2-darwin-arm64.dylib",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-386.so",
-                "name": "tls-client-xgo-1.11.2-linux-386.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-amd64.so",
-                "name": "tls-client-xgo-1.11.2-linux-amd64.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-arm-5.so",
-                "name": "tls-client-xgo-1.11.2-linux-arm-5.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-arm-6.so",
-                "name": "tls-client-xgo-1.11.2-linux-arm-6.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-arm-7.so",
-                "name": "tls-client-xgo-1.11.2-linux-arm-7.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-arm64.so",
-                "name": "tls-client-xgo-1.11.2-linux-arm64.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-ppc64le.so",
-                "name": "tls-client-xgo-1.11.2-linux-ppc64le.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-riscv64.so",
-                "name": "tls-client-xgo-1.11.2-linux-riscv64.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-s390x.so",
-                "name": "tls-client-xgo-1.11.2-linux-s390x.so",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-windows-386.dll",
-                "name": "tls-client-xgo-1.11.2-windows-386.dll",
-            },
-            {
-                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-windows-amd64.dll",
-                "name": "tls-client-xgo-1.11.2-windows-amd64.dll",
-            },
-        ],
-    }
 
     @staticmethod
     def _parse_version(version_string: str) -> Tuple[int, ...]:
@@ -259,35 +170,94 @@ class TLSLibrary:
                     logger.error(f"Error removing old library file {file_path}: {e}")
 
     @classmethod
+    def import_config(cls) -> Optional[dict]:
+        """Loads release data from local disk."""
+        if os.path.exists(RELEASE_CONFIG_PATH):
+            try:
+                with open(RELEASE_CONFIG_PATH, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception as e:
+                logger.error(f"Error loading local release config: {e}")
+        return None
+
+    @classmethod
+    def export_config(cls, data: dict):
+        """Saves release data to local disk."""
+        try:
+            os.makedirs(BIN_DIR, exist_ok=True)
+            with open(RELEASE_CONFIG_PATH, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=4)
+            logger.info(f"Saved release config to {RELEASE_CONFIG_PATH}")
+        except Exception as e:
+            logger.error(f"Error saving local release config: {e}")
+
+    @classmethod
     def fetch_api(cls, version: str = None, retries: int = 3):
-        def _find_release(data, version_: str = None):
-            releases = [Release.from_kwargs(**kwargs) for kwargs in data]
+        def _process_data(data):
+            releases_data = data if isinstance(data, list) else [data]
 
-            if version_ is not None:
-                version_ = "v%s" % version_ if not str(version_).startswith("v") else str(version_)
-                releases = [release for release in releases if re.search(version_, release.name, re.I)]
+            releases = [Release.from_kwargs(**kwargs) for kwargs in releases_data]
 
+            if version is not None:
+                version_ = "v%s" % version if not str(version).startswith("v") else str(version)
+                releases = [release for release in releases if re.search(version_, release.name or release.tag_name, re.I)]
+
+            found_urls = False
             for release in releases:
                 for asset in release.assets:
-                    if IS_UBUNTU and PATTERN_UBUNTU_RE.search(asset.browser_download_url):
+                    if IS_UBUNTU and PATTERN_UBUNTU_RE.search(asset.name):
                         ubuntu_urls.append(asset.browser_download_url)
-                    if PATTERN_RE.search(asset.browser_download_url):
+                        found_urls = True
+                    if PATTERN_RE.search(asset.name):
                         asset_urls.append(asset.browser_download_url)
+                        found_urls = True
+            return found_urls
 
         asset_urls, ubuntu_urls = [], []
+        api_data = None
+
         for _ in range(retries):
             try:
-                # Use standard library's urllib to fetch API data
                 with urllib.request.urlopen(GITHUB_API_URL, timeout=10) as response:
                     if response.status == 200:
                         content = response.read().decode("utf-8")
-                        _find_release(json.loads(content))
-                        break
+                        api_data = json.loads(content)
+                        # Save the first element (latest release) to local config
+                        if isinstance(api_data, list) and api_data:
+                            cls.export_config(api_data[0])
+                        elif isinstance(api_data, dict):
+                            cls.export_config(api_data)
+
+                        if _process_data(api_data):
+                            logger.info("Fetched release data from GitHub API.")
+                            break
             except Exception as ex:
-                logger.error("Unable to fetch GitHub API: %s" % ex)
+                logger.debug(f"GitHub API fetch failed (Attempt {_+1}): {ex}")
 
         if not asset_urls and not ubuntu_urls:
-            _find_release([cls._STATIC_API_DATA])
+            local_data = cls.import_config()
+            if local_data:
+                _process_data(local_data)
+                logger.info(f"Loaded release data from local config: {RELEASE_CONFIG_PATH}")
+            else:
+                # Last resort: construct a direct download URL based on naming patterns
+                # This works if API is rate-limited and no local config exists
+                v_tag = version or LATEST_VERSION_TAG_NAME
+                if not v_tag.startswith("v"):
+                    v_tag = f"v{v_tag}"
+                v_num = v_tag.lstrip("v")
+
+                target_platform = "ubuntu" if IS_UBUNTU else PLATFORM
+                target_arch = MACHINE
+                if PLATFORM == "windows":
+                    if MACHINE == "amd64":
+                        target_arch = "64"
+                    elif MACHINE == "386":
+                        target_arch = "32"
+                direct_filename = f"tls-client-{target_platform}-{target_arch}-{v_num}.{FILE_EXT}"
+                direct_url = f"https://github.com/bogdanfinn/tls-client/releases/download/{v_tag}/{direct_filename}"
+                asset_urls.append(direct_url)
+                logger.info(f"Fallback: generated direct download URL: {direct_url}")
 
         for url in ubuntu_urls:
             yield url

--- a/tls_requests/models/request.py
+++ b/tls_requests/models/request.py
@@ -26,14 +26,22 @@ class Request:
         cookies: CookieTypes = None,
         proxy: ProxyTypes = None,
         timeout: TimeoutTypes = None,
+        protocol_racing: bool = None,
+        allow_http: bool = None,
+        stream_id: int = None,
+        **kwargs,
     ) -> None:
         self._content = None
         self._session_id = None
+        self._extra_config = kwargs
         self.url = URL(url, params=params)
         self.method = method.upper()
         self.cookies = Cookies(cookies)
         self.proxy = Proxy(proxy) if proxy else None
         self.timeout = timeout if isinstance(timeout, (float, int)) else DEFAULT_TIMEOUT
+        self.protocol_racing = protocol_racing
+        self.allow_http = allow_http
+        self.stream_id = stream_id
         self.stream = StreamEncoder(data, files, json)
         self.headers = self._prepare_headers(headers)
 

--- a/tls_requests/settings.py
+++ b/tls_requests/settings.py
@@ -1,18 +1,49 @@
 from __future__ import annotations
 
-from .__version__ import __version__
-
 CHUNK_SIZE = 65_536
 DEFAULT_TIMEOUT = 30.0
 DEFAULT_MAX_REDIRECTS = 9
 DEFAULT_FOLLOW_REDIRECTS = True
 DEFAULT_TLS_DEBUG = False
+DEFAULT_TLS_PROTOCOL_RACING = True
+DEFAULT_TLS_ALLOW_HTTP = False
 DEFAULT_TLS_INSECURE_SKIP_VERIFY = False
 DEFAULT_TLS_HTTP2 = "auto"
 DEFAULT_TLS_IDENTIFIER = "chrome_133"
-DEFAULT_HEADERS = {
-    "accept": "*/*",
-    "connection": "keep-alive",
-    "user-agent": f"Python-TLS-Requests/{__version__}",
-    "accept-encoding": "gzip, deflate, br, zstd",
+
+BROWSER_HEADERS = {
+    "chrome": {
+        "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+        "accept-language": "en-US,en;q=0.9",
+        "accept-encoding": "gzip, deflate, br, zstd",
+        "sec-ch-ua": '"Not(A:Brand";v="99", "Google Chrome";v="133", "Chromium";v="133"',
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": '"Windows"',
+        "sec-fetch-dest": "document",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-site": "none",
+        "sec-fetch-user": "?1",
+        "upgrade-insecure-requests": "1",
+    },
+    "firefox": {
+        "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0",
+        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "accept-language": "en-US,en;q=0.5",
+        "accept-encoding": "gzip, deflate, br, zstd",
+        "upgrade-insecure-requests": "1",
+        "sec-fetch-dest": "document",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-site": "none",
+        "sec-fetch-user": "?1",
+    },
+    "safari": {
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "accept-language": "en-US,en;q=0.9",
+        "accept-encoding": "gzip, deflate, br",
+        "sec-fetch-dest": "document",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-site": "none",
+    }
 }

--- a/tls_requests/types.py
+++ b/tls_requests/types.py
@@ -115,6 +115,7 @@ TLSIdentifierTypes = Union[
         "zalando_ios_mobile",
     ],
     "TLSIdentifierRotator",
+    str,
 ]
 
 AnyList = List[


### PR DESCRIPTION

This PR brings significant improvements to the library's robustness, updates the underlying  tls-client  binary to the latest version, and introduces long-awaited features for dynamic header synchronization.

### 🚀 Key Changes

#### 1. Library Management & Reliability

-   **Upgrade to v1.13.1**: Updated the default library version to the latest stable release.
-   **JSON Configuration Cache**: Introduced  release.json  (stored in  `bin/`) to cache GitHub release metadata. This significantly improves startup time and bypasses GitHub API 403 Rate Limit issues.
-   **Robust Fallback Mechanism**: Implemented a "Bootstrap Fallback" that dynamically constructs download URLs based on the user's platform and architecture if both the API and local cache are unavailable.
-   **Auto-Cleanup**: Improved binary management to automatically remove outdated library files upon successful upgrade.

#### 2. Enhanced TLS Configuration

-   **Protocol Racing**: Added support for  protocol_racing  (enabling Happy Eyeballs for faster connection establishment, particularly useful for HTTP/3).
-   **HTTP/2 & HTTP/3 Support**: Added  allow_http  and  stream_id  parameters.
-   **Extra Kwargs Persistence**: Introduced  `extra_kwargs`  to support arbitrary parameters required by the Go library (e.g.,  local_address,  `custom_settings_order`) without requiring explicit model updates.

#### 3. Dynamic Browser Header Injection

-   **Version Synchronization**: Implemented regex-based logic to extract browser versions from  `tls_identifier`  (e.g.,  `chrome_133`) and automatically inject them into  `User-Agent`  and  `sec-ch-ua`  headers.
-   **Settings Migration**: Moved from static  `DEFAULT_HEADERS`  to a more flexible  `BROWSER_HEADERS`  structure in  `settings.py`.

### How to Test

1.  **Library Upgrade**: Delete files in  bin  and run  TLSLibrary.load(). It should automatically download v1.13.1.
2.  **Dynamic Headers**:
```
import  tls_requests

resp  =  tls_requests.get("https://httpbin.org/headers", tls_identifier="chrome_133")

print(resp.json()["headers"]["User-Agent"]) # Should show version 133
```

3.  **Protocol Racing**:
    
```
# No need to pass protocol_racing=True anymore, it's automatic!
resp  = tls_requests.get("https://httpbin.org/get")
assert  resp.status_code ==  200
# You can still disable it if needed:
resp  = tls_requests.get("https://httpbin.org/get", protocol_racing=False)
```
